### PR TITLE
fix: Create CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @chibie @jeremy0x will be requested for
+# review when someone opens a pull request.
+*       @chibie @jeremy0x


### PR DESCRIPTION
By submitting a PR to this repository, you agree to the terms within the [Paycrest Code of Conduct](https://paycrest.notion.site/Contributor-Code-of-Conduct-1602482d45a2806bab75fd314b381f4c). Please see the [contributing guidelines](https://paycrest.notion.site/Contribution-Guide-1602482d45a2809a8930e6ad565c906a?pvs=4) for how to create and submit a high-quality PR for this repo.

### Description

> This pull request includes a small change to the `.github/CODEOWNERS` file. The change assigns default ownership of the repository to the users `@chibie` and `@jeremy0x` for review purposes.

* [`.github/CODEOWNERS`](diffhunk://#diff-3d36a1bf06148bc6ba1ce2ed3d19de32ea708d955fed212c0d27c536f0bd4da7R1-R5): Added default owners `@chibie` and `@jeremy0x` for the entire repository.


### References
`.github/CODEOWNERS` 

### Checklist

- [x] I have added documentation for new/changed functionality in this PR
- [x] All active GitHub checks for tests, formatting, and security are passing
- [ ] The correct base branch is being used, if not `master`